### PR TITLE
feat: add email auth provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "mapbox-gl": "^2.15.0",
         "next": "13.4.9",
         "next-auth": "^4.22.3",
+        "nodemailer": "^6.9.4",
         "playwright": "^1.36.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -3978,6 +3979,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mapbox-gl": "^2.15.0",
     "next": "13.4.9",
     "next-auth": "^4.22.3",
+    "nodemailer": "^6.9.4",
     "playwright": "^1.36.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/lib/next-auth.tsx
+++ b/src/lib/next-auth.tsx
@@ -4,8 +4,6 @@ import { PrismaAdapter } from '@next-auth/prisma-adapter';
 
 import prisma from '@/lib/prisma';
 
-console.log(process.env.EMAIL_SERVER_HOST);
-
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -20,18 +18,18 @@ export const authOptions = {
         },
       },
     }),
-  ],
-  ...(process.env.EMAIL_SERVER_HOST
-    ? EmailProvider({
-        server: {
-          host: process.env.EMAIL_SERVER_HOST,
-          port: process.env.EMAIL_SERVER_PORT,
-          auth: {
-            user: process.env.EMAIL_SERVER_USER,
-            pass: process.env.EMAIL_SERVER_PASSWORD,
+    process.env.EMAIL_SERVER_HOST
+      ? EmailProvider({
+          server: {
+            host: process.env.EMAIL_SERVER_HOST,
+            port: process.env.EMAIL_SERVER_PORT,
+            auth: {
+              user: process.env.EMAIL_SERVER_USER,
+              pass: process.env.EMAIL_SERVER_PASSWORD,
+            },
           },
-        },
-        from: process.env.EMAIL_FROM,
-      })
-    : []),
+          from: process.env.EMAIL_FROM,
+        })
+      : null,
+  ].filter(Boolean),
 };

--- a/src/lib/next-auth.tsx
+++ b/src/lib/next-auth.tsx
@@ -30,7 +30,7 @@ const emailProvider = EmailProvider({
   from: process.env.EMAIL_FROM,
 });
 
-const providers: Array<Provider> = [googleProvider, emailProvider];
+const providers: Array<Provider> = [googleProvider];
 
 if (process.env.EMAIL_SERVER_HOST) {
   providers.push(emailProvider);

--- a/src/lib/next-auth.tsx
+++ b/src/lib/next-auth.tsx
@@ -2,34 +2,41 @@ import GoogleProvider from 'next-auth/providers/google';
 import EmailProvider from 'next-auth/providers/email';
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
 
-import prisma from '@/lib/prisma';
+import prismaClient from '@/lib/prisma';
+import { AuthOptions } from 'next-auth';
+import { Provider } from 'next-auth/providers';
 
-export const authOptions = {
-  adapter: PrismaAdapter(prisma),
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-      authorization: {
-        params: {
-          prompt: 'consent',
-          access_type: 'offline',
-          response_type: 'code',
-        },
-      },
-    }),
-    process.env.EMAIL_SERVER_HOST
-      ? EmailProvider({
-          server: {
-            host: process.env.EMAIL_SERVER_HOST,
-            port: process.env.EMAIL_SERVER_PORT,
-            auth: {
-              user: process.env.EMAIL_SERVER_USER,
-              pass: process.env.EMAIL_SERVER_PASSWORD,
-            },
-          },
-          from: process.env.EMAIL_FROM,
-        })
-      : null,
-  ].filter(Boolean),
+const googleProvider = GoogleProvider({
+  clientId: process.env.GOOGLE_CLIENT_ID as string,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+  authorization: {
+    params: {
+      prompt: 'consent',
+      access_type: 'offline',
+      response_type: 'code',
+    },
+  },
+});
+
+const emailProvider = EmailProvider({
+  server: {
+    host: process.env.EMAIL_SERVER_HOST,
+    port: process.env.EMAIL_SERVER_PORT,
+    auth: {
+      user: process.env.EMAIL_SERVER_USER,
+      pass: process.env.EMAIL_SERVER_PASSWORD,
+    },
+  },
+  from: process.env.EMAIL_FROM,
+});
+
+const providers: Array<Provider> = [googleProvider, emailProvider];
+
+if (process.env.EMAIL_SERVER_HOST) {
+  providers.push(emailProvider);
+}
+
+export const authOptions: AuthOptions = {
+  adapter: PrismaAdapter(prismaClient),
+  providers: providers,
 };

--- a/src/lib/next-auth.tsx
+++ b/src/lib/next-auth.tsx
@@ -1,6 +1,10 @@
 import GoogleProvider from 'next-auth/providers/google';
+import EmailProvider from 'next-auth/providers/email';
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
+
 import prisma from '@/lib/prisma';
+
+console.log(process.env.EMAIL_SERVER_HOST);
 
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
@@ -17,4 +21,17 @@ export const authOptions = {
       },
     }),
   ],
+  ...(process.env.EMAIL_SERVER_HOST
+    ? EmailProvider({
+        server: {
+          host: process.env.EMAIL_SERVER_HOST,
+          port: process.env.EMAIL_SERVER_PORT,
+          auth: {
+            user: process.env.EMAIL_SERVER_USER,
+            pass: process.env.EMAIL_SERVER_PASSWORD,
+          },
+        },
+        from: process.env.EMAIL_FROM,
+      })
+    : []),
 };


### PR DESCRIPTION
configure email provider.
This will only be enabled when `process.env.EMAIL_FROM` is available, so it is possible to enable it only on preview env (enabling authentication on vercel preview links)